### PR TITLE
Output iters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,7 @@ impl Iterator for GimliAeadDecryptIter{
         let state_ptr = self.state.as_ptr() as *mut u8;
         let state_8 = unsafe {std::slice::from_raw_parts_mut(state_ptr, 48)};
 
-        if self.cipher_message_len > 16 {
+        if self.cipher_message_len >= 16 {
             for i in 0..16 {
                 let current_byte = self.cipher_message.next().unwrap().expect("Read error on input");
                 self.output_buffer.push(state_8[i] ^ current_byte);
@@ -310,8 +310,7 @@ impl Iterator for GimliAeadDecryptIter{
             return Some(self.output_buffer.remove(0))
         }
 
-        if self.cipher_message_len <= 16 && self.cipher_message_len > 0 {
-            println!("c.len: {:?}, o.len: {:?}", self.cipher_message_len, self.output_buffer.len());
+        if self.cipher_message_len <= 15 && self.cipher_message_len > 0 {
             for i in 0..self.cipher_message_len {
                 let current_byte = self.cipher_message.next().unwrap().expect("Read error on input");
                 self.output_buffer.push(state_8[i] ^ current_byte);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl Iterator for GimliAeadDecryptIter{
             }
             result = result.overflowing_sub(1).0;
             result = result >> 16;
-            assert_ne!(result, 0);
+            assert_ne!(result, 0); // Need a better way to express an error than panic
             match self.output_buffer.len() {
                 0 => return None,
                 _ => return Some(self.output_buffer.remove(0)),
@@ -492,7 +492,6 @@ mod tests{
                 Box::new(ct.clone()),
                 assoc_d,
                 );
-            println!("Testing ct:{:?}, pt:{:?}", ct, pt);
             let pt: Vec<u8> = gd_iter.collect();
             assert_eq!(pt, pt);
             assert_eq!(pt, gimli_aead_decrypt(


### PR DESCRIPTION
Mixed up this and the miri CI fixes. This PR adds output iters for both encryption and decryption as well as a number of pointer re-validations to pass miri testing locally.